### PR TITLE
Remove deprecated full RAM guide

### DIFF
--- a/cogs/links.py
+++ b/cogs/links.py
@@ -48,10 +48,7 @@ class Links(Cog):
                        "<https://guide.sdsetup.com/usingcfw/manualchoiupgrade>\n"
                        "How to get started developing Homebrew: "
                        "<https://gbatemp.net/threads/"
-                       "tutorial-switch-homebrew-development.507284/>\n"
-                       "Use full RAM in homebrew without installing NSPs: "
-                       "<https://gbatemp.net/threads/use-atmosphere-to-"
-                       "access-full-ram-with-homebrews-without-nsp.521240/>")
+                       "tutorial-switch-homebrew-development.507284/>\n")
 
     @commands.command()
     async def source(self, ctx):

--- a/cogs/links.py
+++ b/cogs/links.py
@@ -48,7 +48,9 @@ class Links(Cog):
                        "<https://guide.sdsetup.com/usingcfw/manualchoiupgrade>\n"
                        "How to get started developing Homebrew: "
                        "<https://gbatemp.net/threads/"
-                       "tutorial-switch-homebrew-development.507284/>\n")
+                       "tutorial-switch-homebrew-development.507284/>\n"
+                       "Getting full RAM in homebrew without NSPs: "
+                       "as of Atmosphere 0.8.6, hold R while opening any game.")
 
     @commands.command()
     async def source(self, ctx):


### PR DESCRIPTION
As of AMS 0.8.6, just hold R while running a game/app to get full RAM.