### PR TITLE
Show dderr value number if not in list

### DIFF
--- a/cogs/err.py
+++ b/cogs/err.py
@@ -47,11 +47,11 @@ class Err(Cog):
             summ = (rc >> 21) & 0x3F
             level = (rc >> 27) & 0x1F
             embed = discord.Embed(title=f"0x{rc:X}")
-            embed.add_field(name="Module", value=dds_modules[mod])
+            embed.add_field(name="Module", value=dds_modules.get(mod, mod))
             embed.add_field(name="Description",
-                            value=dds_descriptions[desc])
-            embed.add_field(name="Summary", value=dds_summaries[summ])
-            embed.add_field(name="Level", value=dds_levels[level])
+                            value=dds_descriptions.get(desc, desc))
+            embed.add_field(name="Summary", value=dds_summaries.get(summ, summ))
+            embed.add_field(name="Level", value=dds_levels.get(level, level))
             embed.set_footer(text="Console: 3DS")
 
             await ctx.send(embed=embed)


### PR DESCRIPTION
If one of the values does not exist in the error code list for the 0x* errors with dderr, the bot will run into an exception.
This makes it so it shows the number so users can check what the error on 3dbrew (if it exists on there) and still see the other relevant information.