### PR TITLE
Fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/Rapptz/discord.py@rewrite
+git+https://github.com/Rapptz/discord.py
 
 asyncio
 python-dateutil


### PR DESCRIPTION
The `rewrite` branch of discord.py no longer exists, presumably it has been merged into `master` since then.
Remove `@rewrite` from discord.py line in the pip requirements file.