### PR TITLE
Add a link to NH in the newcomers text.

### DIFF
--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -15,6 +15,8 @@ welcome_header = """
 
 __**Be sure you read the following rules and information before participating. If you came here to ask about "backups", this is NOT the place.**__
 
+__**This is a server for technical discussion. If you are just looking for help, the Nintendo Homebrew discord server may be a better fit: <https://discord.gg/C29hYvh>.**__
+
 __**Got questions about Nintendo Switch hacking? Before asking in the server, please see our FAQ at <https://reswitched.team/faq/> to see if your question has already been answered.**__
 
 ​:bookmark_tabs:__Rules:__

--- a/cogs/verification.py
+++ b/cogs/verification.py
@@ -15,7 +15,7 @@ welcome_header = """
 
 __**Be sure you read the following rules and information before participating. If you came here to ask about "backups", this is NOT the place.**__
 
-__**This is a server for technical discussion. If you are just looking for help, the Nintendo Homebrew discord server may be a better fit: <https://discord.gg/C29hYvh>.**__
+__**This is a server for technical discussion and development support. If you are looking for end-user support, the Nintendo Homebrew discord server may be a better fit: https://discord.gg/C29hYvh.**__
 
 __**Got questions about Nintendo Switch hacking? Before asking in the server, please see our FAQ at <https://reswitched.team/faq/> to see if your question has already been answered.**__
 


### PR DESCRIPTION
only concern I have about this as-is is that iirc the embed for the invite will show up between "Rules:" and the actual rules because that's where the message break occurs. we could add the "Rules:" text to the first rule to help fix that?