### PR TITLE
Removed "by ID" commands

### DIFF
--- a/cogs/mod_note.py
+++ b/cogs/mod_note.py
@@ -18,15 +18,6 @@ class ModNote(Cog):
                 "notes", target.name)
         await ctx.send(f"{ctx.author.mention}: noted!")
 
-    @commands.guild_only()
-    @commands.check(check_if_staff)
-    @commands.command(aliases=["addnoteid"])
-    async def noteid(self, ctx, target: int, *, note: str = ""):
-        """Adds a note to a user by userid, staff only."""
-        userlog(target, ctx.author, note,
-                "notes")
-        await ctx.send(f"{target.mention}: noted!")
-
 
 def setup(bot):
     bot.add_cog(ModNote(bot))

--- a/cogs/mod_userlog.py
+++ b/cogs/mod_userlog.py
@@ -121,9 +121,9 @@ class ModUserlog(Cog):
 
     @commands.guild_only()
     @commands.check(check_if_staff)
-    @commands.command(aliases=["listwarnsid"])
-    async def userlogid(self, ctx, target: int):
-        """Lists the userlog events for a user by ID, staff only."""
+    @commands.command(aliases=["listwarns","userlogid","listwarnsid"])
+    async def userlog(self, ctx, target: discord.Member):
+        """Lists the userlog events for a user, staff only."""
         embed = self.get_userlog_embed_for_id(str(target), str(target))
         await ctx.send(embed=embed)
 
@@ -142,17 +142,6 @@ class ModUserlog(Cog):
               f"{safe_name}"
         await log_channel.send(msg)
 
-    @commands.guild_only()
-    @commands.check(check_if_staff)
-    @commands.command(aliases=["clearwarnsid"])
-    async def cleareventid(self, ctx, target: int, event="warns"):
-        """Clears all events of given type for a userid, staff only."""
-        log_channel = self.bot.get_channel(config.modlog_channel)
-        msg = self.clear_event_from_id(str(target), event)
-        await ctx.send(msg)
-        msg = f"🗑 **Cleared {event}**: {ctx.author.mention} cleared"\
-              f" all {event} events of <@{target}> "
-        await log_channel.send(msg)
 
     @commands.guild_only()
     @commands.check(check_if_staff)
@@ -174,23 +163,6 @@ class ModUserlog(Cog):
         else:
             await ctx.send(del_event)
 
-    @commands.guild_only()
-    @commands.check(check_if_staff)
-    @commands.command(aliases=["delwarnid"])
-    async def deleventid(self, ctx, target: int, idx: int, event="warns"):
-        """Removes a specific event from a userid, staff only."""
-        log_channel = self.bot.get_channel(config.modlog_channel)
-        del_event = self.delete_event_from_id(str(target), idx, event)
-        event_name = userlog_event_types[event].lower()
-        # This is hell.
-        if isinstance(del_event, discord.Embed):
-            await ctx.send(f"<@{target}> has a {event_name} removed!")
-            msg = f"🗑 **Deleted {event_name}**: "\
-                  f"{ctx.author.mention} removed "\
-                  f"{event_name} {idx} from <@{target}> "
-            await log_channel.send(msg, embed=del_event)
-        else:
-            await ctx.send(del_event)
 
     @commands.guild_only()
     @commands.check(check_if_staff)

--- a/cogs/mod_watch.py
+++ b/cogs/mod_watch.py
@@ -17,13 +17,6 @@ class ModWatch(Cog):
         setwatch(target.id, ctx.author, True, target.name)
         await ctx.send(f"{ctx.author.mention}: user is now on watch.")
 
-    @commands.guild_only()
-    @commands.check(check_if_staff)
-    @commands.command()
-    async def watchid(self, ctx, target: int, *, note: str = ""):
-        """Puts a user under watch by userid, staff only."""
-        setwatch(target, ctx.author, True, target.name)
-        await ctx.send(f"{target.mention}: user is now on watch.")
 
     @commands.guild_only()
     @commands.check(check_if_staff)
@@ -32,15 +25,6 @@ class ModWatch(Cog):
         """Removes a user from watch, staff only."""
         setwatch(target.id, ctx.author, False, target.name)
         await ctx.send(f"{ctx.author.mention}: user is now not on watch.")
-
-    @commands.guild_only()
-    @commands.check(check_if_staff)
-    @commands.command()
-    async def unwatchid(self, ctx, target: int, *, note: str = ""):
-        """Removes a user from watch by userid, staff only."""
-        setwatch(target, ctx.author, False, target.name)
-        await ctx.send(f"{target.mention}: user is now not on watch.")
-
 
 def setup(bot):
     bot.add_cog(ModWatch(bot))


### PR DESCRIPTION
"by ID" commands are actually not needed, since the discord.py converters will convert a valid ID  to their respective discord objects.