### PR TITLE
Remove asyncio from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 discord.py
-asyncio
 python-dateutil
 humanize
 parsedatetime


### PR DESCRIPTION
asyncio is bundled with Python 3.4+, and the version on PyPI may have issues with newer versions of Python on some configurations.