### PR TITLE
Fix a variable 'roles' referenced before assignment error when relying on default fallback.

### DIFF
--- a/cogs/lockdown.py
+++ b/cogs/lockdown.py
@@ -37,6 +37,7 @@ class Lockdown(Cog):
             channel = ctx.channel
         log_channel = self.bot.get_channel(config.modlog_channel)
 
+        roles = None
         for key, lockdown_conf in config.lockdown_configs.items():
             if channel.id in lockdown_conf["channels"]:
                 roles = lockdown_conf["roles"]
@@ -76,6 +77,7 @@ class Lockdown(Cog):
             channel = ctx.channel
         log_channel = self.bot.get_channel(config.modlog_channel)
 
+        roles = None
         for key, lockdown_conf in config.lockdown_configs.items():
             if channel.id in lockdown_conf["channels"]:
                 roles = lockdown_conf["roles"]


### PR DESCRIPTION
`default` is meant to be the fallback for any locking down channels that aren't defined with an explicit config. 

However, the variable checked for this (the `roles` to lock down for) is not defined unless the for loop matches anything, causing a reference before assignment.

This simply assigns the roles value to `None` before looping to see if a match for role can be found, fixing the problem.