### PR TITLE
Fix broken links to reswitched.team

### DIFF
--- a/cogs/links.py
+++ b/cogs/links.py
@@ -64,7 +64,7 @@ class Links(Cog):
             targetuser = ctx.author
         await ctx.send(
             f"{targetuser.mention}: "
-            "https://reswitched.team/discord/#member-roles-breakdown"
+            "https://reswitched.github.io/discord/#member-roles-breakdown"
             "\n\n"
             "Community role allows access to the set of channels "
             "on the community category (#off-topic, "

--- a/config_template.py
+++ b/config_template.py
@@ -8,7 +8,7 @@ bot_description = "Robocop-NG, the moderation bot of ReSwitched."
 
 # If you forked robocop-ng, put your repo here
 source_url = "https://github.com/reswitched/robocop-ng"
-rules_url = "https://reswitched.team/discord/#rules"
+rules_url = "https://reswitched.github.io/discord/#rules"
 
 # The bot description to be used in .robocop embed
 embed_desc = (
@@ -204,7 +204,7 @@ welcome_header = """
 
 __**Be sure you read the following rules and information before participating. If you came here to ask about "backups", this is NOT the place.**__
 
-__**Got questions about Nintendo Switch hacking? Before asking in the server, please see our FAQ at <https://reswitched.team/faq/> to see if your question has already been answered.**__
+__**Got questions about Nintendo Switch hacking? Before asking in the server, please see our FAQ at <https://reswitched.github.io/faq/> to see if your question has already been answered.**__
 
 __**This is a server for technical discussion and development support. If you are looking for end-user support, the Nintendo Homebrew discord server may be a better fit: <https://discord.gg/C29hYvh>.**__
 


### PR DESCRIPTION
The site has now been moved to reswitched.github.io, with a disclaimer added about its outdated-ness.