### PR TITLE
chungusify robocop

### DIFF
--- a/robocop_ng/helpers/checks.py
+++ b/robocop_ng/helpers/checks.py
@@ -16,7 +16,7 @@ def check_if_bot_manager(ctx):
 def check_if_staff_or_ot(ctx):
     if not ctx.guild:
         return True
-    is_ot = ctx.channel.name == "off-topic"
+    is_ot = ctx.channel.name == "off-topic" or ctx.channel.name == "big-chungus"
     is_bot_cmds = ctx.channel.name == "bot-cmds"
     is_staff = any(r.id in config.staff_role_ids for r in ctx.author.roles)
     return is_ot or is_staff or is_bot_cmds


### PR DESCRIPTION
`check_if_staff_or_ot` has been broken for almost a year now. Oops.

Compliant with [the "Works on My Machine" Certification Program](https://blog.codinghorror.com/the-works-on-my-machine-certification-program/):
> Cause one code path in the code you're checking in to be executed. The preferred way to do this is with ad-hoc manual testing of the simplest possible case for the feature in question. Omit this step if the code change was less than five lines, or if, in the developer's professional opinion, the code change could not *possibly* result in an error. 

The ideal solution would probably be to add an `ot_channel` channel ID to `config.py`, but this seems Good Enough.